### PR TITLE
Add `SCRIPTISTO_CACHE_DIR` environment variable + showcase in new Dart template, support hashing additional paths such as multiple source files or directories

### DIFF
--- a/data/templates/dart_multifile.dart
+++ b/data/templates/dart_multifile.dart
@@ -1,0 +1,11 @@
+#!/usr/bin/env scriptisto
+# This template is meant to compile whole Dart projects instead of a single file
+#
+# scriptisto-begin
+# script_src: dart_multifile_project/main.dart
+# build_in_script_dir: true
+# build_cmd: set -eu && dart compile exe "dart_multifile_project/main.dart" -o "${SCRIPTISTO_CACHE_DIR}/my-dart-program"
+# target_bin: my-dart-program
+# extra_src_paths:
+#   - dart_multifile_project
+# scriptisto-end

--- a/data/templates/dart_multifile_project/functions.dart
+++ b/data/templates/dart_multifile_project/functions.dart
@@ -1,0 +1,7 @@
+// This file will also be checked for changes by scriptisto
+
+import 'dart:io';
+
+String getWorkingDirectory() {
+  return Directory.current.path;
+}

--- a/data/templates/dart_multifile_project/main.dart
+++ b/data/templates/dart_multifile_project/main.dart
@@ -1,0 +1,6 @@
+import 'functions.dart';
+
+void main(List<String> arguments) {
+  print(
+      'Hello Dart, arguments=$arguments getWorkingDirectory()=${getWorkingDirectory()}');
+}

--- a/src/build.rs
+++ b/src/build.rs
@@ -21,7 +21,9 @@ use crate::cfg;
 use crate::common;
 use crate::opt;
 
-const SCRIPTISTO_SOURCE_VAR: &str = "SCRIPTISTO_SOURCE";
+pub const SCRIPTISTO_CACHE_DIR_VAR: &str = "SCRIPTISTO_CACHE_DIR";
+pub const SCRIPTISTO_SOURCE_DIR_VAR: &str = "SCRIPTISTO_SOURCE_DIR";
+pub const SCRIPTISTO_SOURCE_VAR: &str = "SCRIPTISTO_SOURCE";
 
 fn docker_prefix(script_cache_path: &Path) -> Result<String> {
     Ok(format!(
@@ -193,12 +195,30 @@ where
             }
             // Non-Docker build.
             _ => {
+                let script_dir = match script_path.parent() {
+                    None => {
+                        return Err(anyhow!(
+                            "Failed to look up parent directory of {:?}",
+                            script_path
+                        ));
+                    }
+                    Some(p) => p,
+                };
+
                 let mut cmd = Command::new("/bin/sh");
                 cmd.arg("-c")
                     .arg(build_cmd)
+                    .env(SCRIPTISTO_CACHE_DIR_VAR, script_cache_path)
+                    .env(SCRIPTISTO_SOURCE_DIR_VAR, script_dir)
                     .env(SCRIPTISTO_SOURCE_VAR, script_path);
 
-                common::run_command(script_cache_path, cmd, stderr_mode())?;
+                let working_directory = if cfg.build_in_script_dir {
+                    script_dir
+                } else {
+                    script_cache_path
+                };
+
+                common::run_command(working_directory, cmd, stderr_mode())?;
             }
         }
     }
@@ -234,8 +254,73 @@ pub fn perform(
     let metadata_modified = common::file_modified(&metadata_path).ok();
     let script_modified = common::file_modified(script_path).ok();
 
+    // If source file is older than metadata file, also hash other paths. Those could be additional
+    // inputs for the build, for example, which must be considered for triggering a rebuild.
+    let mut additional_paths_max_modified: Option<std::time::SystemTime> = None;
+    if metadata_modified > script_modified {
+        let full_script_path = script_path
+            .canonicalize()
+            .context("Cannot build full path from given script path")?;
+        let script_dir = full_script_path
+            .parent()
+            .expect("script_src has no parent directory");
+
+        let mut num_additional_paths_scanned = 0;
+        for additional_path in cfg.extra_src_paths.iter() {
+            let mut full_additional_path = PathBuf::from(additional_path);
+            if !full_additional_path.is_absolute() {
+                full_additional_path = script_dir.join(additional_path);
+            }
+
+            debug!("Hashing additional path {:?}", full_additional_path);
+
+            for entry_res in walkdir::WalkDir::new(&full_additional_path)
+                .follow_links(true)
+                .into_iter()
+            {
+                debug!("Checking directory entry {:?}", entry_res);
+                if entry_res.is_err() {
+                    continue;
+                }
+                let entry = entry_res.as_ref().unwrap();
+
+                let metadata_res = entry.metadata();
+                if metadata_res.is_ok() && metadata_res.as_ref().unwrap().is_file() {
+                    num_additional_paths_scanned += 1;
+                    if num_additional_paths_scanned > 500000 {
+                        panic!("Too many files scanned");
+                    }
+                    let modified_res = metadata_res.as_ref().unwrap().modified();
+                    if modified_res.is_ok()
+                        && (additional_paths_max_modified.is_none()
+                            || *modified_res.as_ref().unwrap()
+                                > additional_paths_max_modified.unwrap())
+                    {
+                        additional_paths_max_modified = Some(*modified_res.as_ref().unwrap());
+
+                        if metadata_modified <= additional_paths_max_modified {
+                            debug!(
+                                "File {:?} is newer than metadata, causing rebuild",
+                                entry.path()
+                            );
+                            break;
+                        }
+                    } else if modified_res.is_err() {
+                        debug!("Cannot get modification time of {:?}", entry.path());
+                    }
+                }
+            }
+
+            if metadata_modified <= additional_paths_max_modified {
+                break;
+            }
+        }
+    }
+
     let first_run = metadata_modified.is_none();
-    let skip_rebuild = metadata_modified > script_modified && build_mode == opt::BuildMode::Default;
+    let skip_rebuild = metadata_modified > script_modified
+        && metadata_modified > additional_paths_max_modified
+        && build_mode == opt::BuildMode::Default;
 
     if skip_rebuild {
         debug!("Already compiled, skipping compilation");

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -32,6 +32,10 @@ pub struct BuildSpec {
     pub files: Vec<File>,
     #[serde(default)]
     pub docker_build: Option<DockerBuild>,
+    #[serde(default)]
+    pub extra_src_paths: Vec<String>, // paths to directory/file, no wildcards supported
+    #[serde(default)]
+    pub build_in_script_dir: bool, // use script directory as working directory of build, not the cache directory (non-Docker build only)
 }
 
 fn default_target_bin() -> String {

--- a/src/common.rs
+++ b/src/common.rs
@@ -76,7 +76,10 @@ pub fn run_command(
 
     debug!("Running command: {:?}", cmd);
 
-    let out = cmd.output().context(format!("Cannot run: {:?}", cmd))?;
+    let out = cmd.output().context(format!(
+        "Cannot run cmd={:?} in current_directory={:?}",
+        cmd, current_directory
+    ))?;
 
     let stderr = String::from_utf8_lossy(&out.stderr);
     let stdout = String::from_utf8_lossy(&out.stdout);


### PR DESCRIPTION
Sorry, didn't open an issue before. Please add one if this feature isn't clear. To me, hashing more than just the script file itself is essential since many programs consist of multiple source files. This change allows listing files and directories which will trigger a rebuild if their modification time changed (same as scriptisto already does on the source script file). A new Dart template was added and used as show case for an – also new – `SCRIPTISTO_CACHE_DIR` environment variable, which helps the script access any further built artifacts.

- [ ] Tests pass – Manually tested, didn't find any automated tests.
- [ ] Appropriate changes to README are included in PR – No. Changes should be described in the Wiki once merged.