### PR TITLE
Add a COBOL template

### DIFF
--- a/data/templates/cobol.cob
+++ b/data/templates/cobol.cob
@@ -1,0 +1,12 @@
+#!/usr/bin/env scriptisto
+      * scriptisto-begin
+      * script_src: cobol.cob
+      * build_cmd: cobc -x -o script ./cobol.cob
+      * replace_shebang_with: '      * '
+      * scriptisto-end
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. hello.
+       PROCEDURE DIVISION.
+       DISPLAY "Hello, COBOL!".
+       STOP RUN.
+


### PR DESCRIPTION
Fixes #46

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR

Tested with cobc (GnuCOBOL) 3.2.0 (eg: `brew install gnu-cobol`)

```none
$ cat ./cobol.cob
#!/usr/bin/env scriptisto
      * scriptisto-begin
      * script_src: cobol.cob
      * build_cmd: cobc -x -o script ./cobol.cob
      * replace_shebang_with: '      * '
      * scriptisto-end
       IDENTIFICATION DIVISION.
       PROGRAM-ID. hello.
       PROCEDURE DIVISION.
       DISPLAY "Hello, COBOL!".
       STOP RUN.

$ ./cobol.cob
Hello, COBOL!
$
```