### PR TITLE
Replacing users with uzers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde_derive='1.0'
 serde_yaml='0.9'
 md5="0"
 prettytable-rs="0.10"
-users="0.11"
+uzers="0.12"
 walkdir="2"
 number_prefix="0.4"
 clap = { version = "3", features = ["derive"] }

--- a/src/build.rs
+++ b/src/build.rs
@@ -66,7 +66,7 @@ fn docker_volume_cmd(
     let mut vol_cmd = Command::new("docker");
     vol_cmd.args(["run", "-t", "--rm"]);
     if run_as_current_user {
-        vol_cmd.args(["-u", &format!("{}", users::get_current_uid())]);
+        vol_cmd.args(["-u", &format!("{}", uzers::get_current_uid())]);
     }
     vol_cmd.args([
         "-v",


### PR DESCRIPTION
Hello. users is unmaintained and affected by [RUSTSEC-2023-0059](https://rustsec.org/advisories/RUSTSEC-2023-0059.html). It has been replaced by its fork uzers. Recently I [made the replacement](https://tracker.debian.org/news/1592824/accepted-rust-scriptisto-220-2-source-into-unstable/) in the Debian packaging of scriptisto and had users removed from unstable and testing.

Cheers!